### PR TITLE
INT-406: Add payment section to Partner API docs

### DIFF
--- a/site/hxapi/hotel/bkg/index.md
+++ b/site/hxapi/hotel/bkg/index.md
@@ -91,7 +91,7 @@ The additional parameters for hotel with parking (where parking > 0 days) are:
 
 ## Payment
 
-In the UK, we are PCI DSS compliant and so we do not accept customers' payment details being passed to us via the API.
+In the UK, we are PCI DSS compliant and so we do not accept customers' payment details being passed to us via the API. Further details can be found in our section on [Payment](/hxapi/payment).
 
 Please contact your Account Manager if you have any questions concerning payment.
 

--- a/site/hxapi/parking/bkg.md
+++ b/site/hxapi/parking/bkg.md
@@ -72,7 +72,7 @@ The availability response will return a list of 18 flags in the `<CarDetFlags>` 
 
 ### Payment
 
-In the UK, we are PCI DSS compliant and so we do not accept customers' payment details being passed to us via the API.
+In the UK, we are PCI DSS compliant and so we do not accept customers' payment details being passed to us via the API. Further details can be found in our section on [Payment](/hxapi/payment).
 
 Please contact your Account Manager if you have any questions concerning payment.
 

--- a/site/hxapi/payment.md
+++ b/site/hxapi/payment.md
@@ -19,7 +19,7 @@ To make a payment using SEPA, the following fields must be included in the booki
 | Name | Data Type	| Format	| Mandatory?	| Additional Information |
 |------|------------|---------|-------------|------------------------|
 | AccountName | String |  | Y | Name on the account |
-| AccountNumber | String | See additional information | Y | The IBAN account number. The IBAN number structure comprises 2 character country code, 2 character check digits (integer), followed by up to 30 characters (integers). ![More information on IBAN.](http://www.sepaforcorporates.com/single-euro-payments-area/iban-number-format-sepa-country/) |
+| AccountNumber | String | See additional information | Y | The IBAN account number. The IBAN number structure comprises 2 character country code, 2 character check digits (integer), followed by up to 30 characters (integers). [More information on IBAN.](http://www.sepaforcorporates.com/single-euro-payments-area/iban-number-format-sepa-country/) |
 | SortCode | String |  | Y | The SEPA sort code |
 
 The following test details can be used in sandbox only:
@@ -35,10 +35,10 @@ To make a payment using credit or debit cards, you must use a different endpoint
 The endpoints that must be used are:
 
 Sandbox:
-```https://payment.holidayextras.co.uk/legacy/sandbox/```
+`https://payment.holidayextras.co.uk/legacy/sandbox/`
 
-Production: 
-```https://payment.holidayextras.co.uk/legacy/```
+Production:
+`https://payment.holidayextras.co.uk/legacy/`
 
 In order for us to process the payment, the following fields must be included in the booking request:
 

--- a/site/hxapi/payment.md
+++ b/site/hxapi/payment.md
@@ -18,15 +18,15 @@ To make a payment using SEPA, the following fields must be included in the booki
 
 | Name | Data Type	| Format	| Mandatory?	| Additional Information |
 |------|------------|---------|-------------|------------------------|
-| AccountName | String |  | Y | Name on the account |
+| AccountName | String | [A-Z0-9] | Y | Name on the account |
 | AccountNumber | String | See additional information | Y | The IBAN account number. The IBAN number structure comprises 2 character country code, 2 character check digits (integer), followed by up to 30 characters (integers). [More information on IBAN.](http://www.sepaforcorporates.com/single-euro-payments-area/iban-number-format-sepa-country/) |
-| SortCode | String |  | Y | The SEPA sort code |
+| SortCode | String | [0-9] 11 chars  | Y | The SEPA sort code |
 
 The following test details can be used in sandbox only:
 
-AccountName - Mr T Test
-AccountNumber - DE00000000000000000066
-SortCode - 99999999999
+- AccountName - Mr T Test
+- AccountNumber - DE00000000000000000066
+- SortCode - 99999999999
 
 ### Payment by credit or debit card
 
@@ -35,9 +35,11 @@ To make a payment using credit or debit cards, you must use a different endpoint
 The endpoints that must be used are:
 
 Sandbox:
+
 `https://payment.holidayextras.co.uk/legacy/sandbox/`
 
 Production:
+
 `https://payment.holidayextras.co.uk/legacy/`
 
 In order for us to process the payment, the following fields must be included in the booking request:
@@ -45,26 +47,24 @@ In order for us to process the payment, the following fields must be included in
 | Name | Data Type	| Format	| Mandatory?	| Additional Information |
 |------|------------|---------|-------------|------------------------|
 | CardNumber | String | [0-9] Max 16 chars | Y | Name on the account |
-| StartDate | Date | MMYY | N* | * Start Date is only mandatory for Maestro cards |
 | ExpiryDate | Date | MMYY | Y | The expiry date of the card |
-| IssueNumber | Integer | [0-9] 1 char | N* | Issue number is only mandatory for Maestro cards |
 | CV2 | Integer | [0-9] 4 chars | Y | The 3 digit number printed in the signature space of most cards (For Amex only, it is a 4 digit number printed on the front of the card). Also known as "CVV" or "CVV2".  |
 
 The following test details can be used in sandbox only:
 
-**Visa Credit Card:**
-CardNumber	- 4715059999000437
-ExpiryDate	- 05/21
-CV2	Integer - 222
+#### Visa Credit Card:
+- CardNumber	- 4715059999000437
+- ExpiryDate	- 05/21
+- CV2	Integer - 222
 
-**Visa Debit Card:**
-CardNumber	- 4508750015741019
-ExpiryDate	- 05/21
-CV2	Integer - 222
+#### Visa Debit Card:
+- CardNumber	- 4508750015741019
+- ExpiryDate	- 05/21
+- CV2	Integer - 222
 
-**American Express:**
-CardNumber	- 345678000000007
-ExpiryDate	- 05/21
-CV2	Integer - 2222
+#### American Express:
+- CardNumber	- 345678000000007
+- ExpiryDate	- 05/21
+- CV2	Integer - 2222
 
 NB: We do not provide test card details for the production (live) environment.

--- a/site/hxapi/payment.md
+++ b/site/hxapi/payment.md
@@ -1,0 +1,70 @@
+---
+
+---
+
+# Payment
+
+For all UK partners and any new partners integrating after **1st July 2017**, Holiday Extras will not accept payment details being passed through the API. The responsibility for collecting and processing payment from the customer is the responsibility of the partner.
+
+If you have any questions concerning this then please contact your Account Manager.
+
+## Existing integrations
+
+For existing integrations *in Europe only* we will continue to support the following payment methods via the API:
+
+### SEPA
+
+To make a payment using SEPA, the following fields must be included in the booking request:
+
+| Name | Data Type	| Format	| Mandatory?	| Additional Information |
+|------|------------|---------|-------------|------------------------|
+| AccountName | String |  | Y | Name on the account |
+| AccountNumber | String | See additional information | Y | The IBAN account number. The IBAN number structure comprises 2 character country code, 2 character check digits (integer), followed by up to 30 characters (integers). ![More information on IBAN.](http://www.sepaforcorporates.com/single-euro-payments-area/iban-number-format-sepa-country/) |
+| SortCode | String |  | Y | The SEPA sort code |
+
+The following test details can be used in sandbox only:
+
+AccountName - Mr T Test
+AccountNumber - DE00000000000000000066
+SortCode - 99999999999
+
+### Payment by credit or debit card
+
+To make a payment using credit or debit cards, you must use a different endpoint to that stated in the Detailed Guides. This is to enable us to tokenise the card details before they reach our systems.
+
+The endpoints that must be used are:
+
+Sandbox:
+```https://payment.holidayextras.co.uk/legacy/sandbox/```
+
+Production: 
+```https://payment.holidayextras.co.uk/legacy/```
+
+In order for us to process the payment, the following fields must be included in the booking request:
+
+| Name | Data Type	| Format	| Mandatory?	| Additional Information |
+|------|------------|---------|-------------|------------------------|
+| CardNumber | String | [0-9] Max 16 chars | Y | Name on the account |
+| StartDate | Date | MMYY | N* | * Start Date is only mandatory for Maestro cards |
+| ExpiryDate | Date | MMYY | Y | The expiry date of the card |
+| IssueNumber | Integer | [0-9] 1 char | N* | Issue number is only mandatory for Maestro cards |
+| CV2 | Integer | [0-9] 4 chars | Y | The 3 digit number printed in the signature space of most cards (For Amex only, it is a 4 digit number printed on the front of the card). Also known as "CVV" or "CVV2".  |
+
+The following test details can be used in sandbox only:
+
+**Visa Credit Card:**
+CardNumber	- 4715059999000437
+ExpiryDate	- 05/21
+CV2	Integer - 222
+
+**Visa Debit Card:**
+CardNumber	- 4508750015741019
+ExpiryDate	- 05/21
+CV2	Integer - 222
+
+**American Express:**
+CardNumber	- 345678000000007
+ExpiryDate	- 05/21
+CV2	Integer - 2222
+
+NB: We do not provide test card details for the production (live) environment.


### PR DESCRIPTION
**What does this PR do?**
It adds a new page specifically outlining payment - including:

- Credit / debit card details: which fields need to be sent through, and also details of the test cards that can be used;
- SEPA payment details: which fields need to be sent through and test details;
- Making it clear that all new integrations will not allow payment details to be sent through.

I've also updated the parking and hotel pages to link to payment.

**Gif that best describes how I feel about this work?**
![](https://media.giphy.com/media/ND6xkVPaj8tHO/giphy.gif)
