### PR TITLE
Remove car hire from list

### DIFF
--- a/site/hxapi/index.md
+++ b/site/hxapi/index.md
@@ -16,7 +16,6 @@ Please check the table below for details of which products are available in each
 |[Hotels](/hxapi/hotel)|Yes|Yes|
 |[Lounges](/hxapi/lounge)|Yes|Yes|
 |[Insurance](/hxapi/insurance)|Yes|No|
-|[Car Hire](/hxapi/carhire)|Yes|No|
 
 
 


### PR DESCRIPTION
Car hire is currently written as a Flexible integration. NP are in process of integrating with RentalCars for supply. I expect this will mean the car hire docs will need updating. So for now I have removed car hire from the list of products available, but will leave car hire product guides live so they can be updated by NP when they're ready.