### PR TITLE
INT-1013 Update Partner API regarding Infants mandatory parameter for lounges

### DIFF
--- a/site/hxapi/lounge/av/airport.md
+++ b/site/hxapi/lounge/av/airport.md
@@ -39,8 +39,9 @@ NB: All parameter names are case sensitive.
 | token       | String  | [0-9] 9 chars                         | Y        | Please see [user token endpoint](/hxapi/usertoken) for details of how to generate a token. |
 | ArrivalDate | Date    | YYYY-MM-DD  | Y        | Date customer enters the lounge. |
 | ArrivalTime | Time    | HHMM       | Y        | Time customer enters the lounge. |
-| Adults      | Integer | [0-4] 1 char | Y        | Number of adults requiring entry to the lounge. Please note: a maximum of 4 passengers is permitted on any one booking. |
-| Children    | Integer | [0-3] 1 char | N        | Number of children requiring entry to the lounge. Please note: a maximum of 4 passengers is permitted on any one booking. |
+| Adults      | Integer | [0-4] 1 char | Y        | Number of adults requiring entry to the lounge. Please note: a maximum of 6 passengers is permitted on any one booking. |
+| Children    | Integer | [0-3] 1 char | N        | Number of children requiring entry to the lounge. Please note: a maximum of 6 passengers is permitted on any one booking. |
+| Infants     | Integer | 1 char       | N        | Number of infants requiring entry to the lounge. Please note: a maximum of 6 passengers is permitted on any one booking. |
 | System      | String  | [A-Z] 3 chars | Y*       | For European products, you need to pass in the value of `System=ABG` (the default is `System=ABC`, which is UK products only). |
 | lang        | String  | [A-Z] 2 chars | Y*       | Required for requests for European products. (Values available are `en`, `de`, `it`, `es`, `pt` and `nl`.)|
 

--- a/site/hxapi/lounge/bkg.md
+++ b/site/hxapi/lounge/bkg.md
@@ -39,8 +39,9 @@ NB: All parameter names are case sensitive.
  | token       | String  | [0-9] 9 chars                         | Y        | This is the same token used in the availability request. |
  | ArrivalDate | Date    | YYYY-MM-DD                             | Y        | Date customer wishes to enter the lounge. |
  | ArrivalTime | Time    | HHMM                                   | Y        | Time customer wishes to enter the lounge.|
- | Adults      | Integer | [0-4] 1 char | Y        | Number of adults requiring entry to the lounge. Please note: a maximum of 4 passengers is permitted on any one booking. |
- | Children    | Integer | [0-3] 1 char | N        | Number of children requiring entry to the lounge. Please note: a maximum of 4 passengers is permitted on any one booking. |
+ | Adults      | Integer | [0-4] 1 char | Y        | Number of adults requiring entry to the lounge. Please note: a maximum of 6 passengers is permitted on any one booking. |
+ | Children    | Integer | [0-3] 1 char | N        | Number of children requiring entry to the lounge. Please note: a maximum of 6 passengers is permitted on any one booking. |
+ | Infants     | Integer | 1 char | Y        | Number of infants requiring entry to the lounge. Please note: a maximum of 6 passengers is permitted on any one booking. |
  | Title | String | [0-9] 4 chars | Y        | Title of lead passenger|
  | Initial | String | [A-Z] 1 chars | Y        | Initial of lead passenger|
  | Surname | String | [0-9] 20 chars | Y        | Surname of lead passenger|


### PR DESCRIPTION
- Adds `Infants` parameter for lounges as a mandatory one
- Updates the maximum number of passengers permitted on any lounge booking