### PR TITLE
INT-1092 Add docs for bundles

### DIFF
--- a/site/hxapi/bundles.md
+++ b/site/hxapi/bundles.md
@@ -1,0 +1,80 @@
+# Bundles
+
+Some results that are returned from availability on the API will be what we call bundles, these consist of a main product, such as a hotel, bundled together with an additional supplement, like a dinner.
+
+Bundles are currently only available on hotel searches.
+
+## Availability
+
+Bundles can be identified by their product code, which has an additional element preceding the main product code joined by a `+`.
+
+E.g
+
+``` xml
+...
+<Name>Cresta Court with 2-course dinner</Name>
+<Code>MANCCT+B519</Code>
+<BookingURL>/v1/hotel/HPMANCCT+B519</BookingURL>
+<Price>110.65</Price>
+...
+```
+
+The price given will be for the entire bundle including the supplement with the current passenger quantity ( determined by the given [room code](/hxapi/types/roomcode) ).
+A [product library](/hxapi/productlibrary) request can be made with the complete bundle product code to get content related to the package as a whole instead of simply the main product. E.g `/v1/product/MANCCT+B519`
+
+## Booking
+
+The `BookingURL` element will contain the full product code that must be supplied when a bundle is to be booked, this will ensure that system books the main product as well as the appropriate supplement. When booking a bundle on a hotel search the quantity of the supplement will be determined by the given room occupancy in the `Adults` and `Children` fields.
+
+The booking response for a bundle booking will show the main product and the booked supplement as seperate elements. The `TotalPrice` field will contain the full price of the booking, but the supplement price will also be shown separately under the `CurrentSupplements` block.
+
+E.g
+
+``` xml
+...
+<Booking>
+<BookingRef>XXXXX</BookingRef>
+<AgentComm>12.41</AgentComm>
+<VATonComm>2.07</VATonComm>
+<MoreInfoURL>/v1/booking/XXXXX</MoreInfoURL>
+</Booking>
+<Hotel/>
+<Itinerary>
+<TotalPrice>110.65</TotalPrice>
+<ArrivalDate>2019-03-10</ArrivalDate>
+<Nights>1</Nights>
+<BoardBasis>RO</BoardBasis>
+<NonSmoking>N</NonSmoking>
+<ReturnFlight/>
+<TerminalCode/>
+<Code>MANCCT</Code>
+<Name/>
+<ParkingDays>0</ParkingDays>
+<ParkingSpaces>0</ParkingSpaces>
+</Itinerary>
+<Room>
+<Adults>2</Adults>
+<Children>1</Children>
+<Infants>0</Infants>
+<Code>TRL</Code>
+</Room>
+<CurrentSupplements>
+<Code>MANCDI</Code>
+<Name>2-course dinner</Name>
+<Price>29.90</Price>
+<NonDiscPrice>29.90</NonDiscPrice>
+<Per>person</Per>
+<Adults>2</Adults>
+<Children>1</Children>
+<Date>2019-03-10</Date>
+<Canx>Y</Canx>
+<Remarks/>
+</CurrentSupplements>
+...
+```
+
+The product code of the supplement will also be returned in the booking response which can be used to retrieve product specific content in the [product library](/hxapi/productlibrary) request that can be displayed on booking confirmations.
+
+## Post Booking
+
+A bundle booking can be amended or cancelled following the same rules as a general product. The supplement has a `Canx` field in the booking response that will define if that particular add-on can be cancelled as part of the booking. It is not currently possible to amend the quantity of the supplement or remove it from the booking using the API.

--- a/site/hxapi/bundles.md
+++ b/site/hxapi/bundles.md
@@ -73,7 +73,7 @@ E.g
 ...
 ```
 
-The product code of the supplement will also be returned in the booking response which can be used to retrieve product specific content in the [product library](/hxapi/productlibrary) request that can be displayed on booking confirmations.
+The product code of the supplement will also be returned in the booking response which can be used to retrieve product specific content in the [product library](/hxapi/productlibrary) request that can be displayed on booking confirmations. When creating confirmation emails be sure to highlight that the supplement has been added as a part of this booking.
 
 ## Post Booking
 

--- a/site/hxapi/index.md
+++ b/site/hxapi/index.md
@@ -33,6 +33,7 @@ These endpoints are not product-specific. Please check the table below for detai
 |[Product library](/hxapi/productlibrary)|Yes|Yes|
 |[Managing a booking](/hxapi/viewamendcancel)|Yes|Yes|
 |[Update a booking's flight](/hxapi/flightUpdate)|Yes|No|
+|[Bundles](/hxapi/bundles)|Yes|No|
 
 ## "DE-Start" Product Guides
 

--- a/site/index.md
+++ b/site/index.md
@@ -17,6 +17,7 @@ The purpose of this documentation is to enable you to quickly on-board with our 
 
 |Version Number|Date|Details|
 |--------------|----|-------|
+| 1.11.0 | 6th February 2019 | Added docs explaining bundle products |
 | 1.10.0 | 25th January 2019 | Added optional `Terminal` param for hotel with parking requests. |
 |1.9.6 | 6th December 2018 | Updated sandbox hostname for legacy payments (EU) |
 |1.9.5 | 3rd October 2018 | Mandatory Infants parameter added for Lounges.|

--- a/site/index.md
+++ b/site/index.md
@@ -17,7 +17,7 @@ The purpose of this documentation is to enable you to quickly on-board with our 
 
 |Version Number|Date|Details|
 |--------------|----|-------|
-| 1.11.0 | 6th February 2019 | Added docs explaining bundle products |
+| 1.11.0 | 27th March 2019 | Added docs explaining bundle products |
 | 1.10.0 | 25th January 2019 | Added optional `Terminal` param for hotel with parking requests. |
 |1.9.6 | 6th December 2018 | Updated sandbox hostname for legacy payments (EU) |
 |1.9.5 | 3rd October 2018 | Mandatory Infants parameter added for Lounges.|


### PR DESCRIPTION
Adds specific documentation for bundles, explaining how they can be identified in a search, how to book them etc.