### PR TITLE
Nights should always be set as '1' 

### DIFF
--- a/site/hxapi/hotel/av/index.md
+++ b/site/hxapi/hotel/av/index.md
@@ -42,7 +42,7 @@ NB: All parameter names are case sensitive.
  | key         | String  | [A-Z]                                  | Y        | This will be assigned to you by your Account Manager during set up.|
  | token       | String  | [0-9] 9 chars                         | Y        | Please see [user token endpoint](/hxapi/usertoken) for details of how to generate a token. |
  | ArrivalDate | Date    | YYYY-MM-DD                             | Y        | Date customer arrives at hotel. |
- | Nights      | Integer  | 1, 2, 3, etc                                  | Y        | Number of nights the customer wants to stay in the hotel. NB: For European products it is only possible to book one night stays.|
+ | Nights      | Integer  | 1                                  | Y        | Number of nights the customer wants to stay in the hotel. NB: It is only possible to book one night stays.|
  | RoomType      | String  | [A-Z0-9] 3 chars | Y        | See [RoomCodes](/hxapi/types/roomcode) for a list of valid codes. |
  | SecondRoomType        | String  | [A-Z0-9] 3 chars | N*        | NB: This feature is only available in the UK. <br>This parameter is mandatory if the customer wishes to book two rooms at the same time. <br>The room codes are as per RoomType. |
  | ParkingDays       | Integer  | [0-9] 2 chars | Y        | NB: The maximum duration accepted for ParkingDays is 30.|


### PR DESCRIPTION
WHY ARE WE DOING THIS AND HOW URGENT IS IT/WHAT IMPACT IS THERE?

We currently have incorrect info in our API doc which refers to customers being able to book a hotel for multiple nights however this is not possible and price will return the single night price no matter how many nights the partner enters.

https://docs.holidayextras.co.uk/hxapi/hotel/av/

Nights should always be set as '1' to avoid confusion and partners integrating incorrectly.