### PR TITLE
INT-1160 Token payment clarification

### DIFF
--- a/site/payment-gateway/pay.md
+++ b/site/payment-gateway/pay.md
@@ -10,6 +10,8 @@
 
 This endpoint will take payment using a token and required payment parameters.
 
+**Note**: Token payment is currently available for Level 5 Germany agents only.
+
 ### Method
 
 POST


### PR DESCRIPTION
Added a tiny clarification about who is able to use token payments.

From @sparkymarky79 :
https://docs.holidayextras.co.uk/payment-gateway/pay/ that ticket about token we believe is just for Germany and no UK agents - Level 5 only
