### PR TITLE
Updating max character for car make, model and colour

### DIFF
--- a/site/hxapi/parking/av/_car_det_flags.md
+++ b/site/hxapi/parking/av/_car_det_flags.md
@@ -1,4 +1,4 @@
   | 1        | Registration   | String | See [Expanded Formats](/hxapi/formats/#car-details)     | Vehicle registration number <br> NB: This field is not validated through the API. |
-  | 2        | CarMake        | String | [A-Z0-9] 20 chars      | Make of vehicle, e.g. Audi.                                             |
-  | 3        | CarModel       | String | [A-Z0-9] 20 chars      | Model of vehicle, e.g. A6.                                               |
-  | 4        | CarColour      | String | [A-Z0-9] 20 chars      | Colour of vehicle, e.g. White.                                           |
+  | 2        | CarMake        | String | [A-Z0-9] 25 chars      | Make of vehicle, e.g. Audi.                                             |
+  | 3        | CarModel       | String | [A-Z0-9] 25 chars      | Model of vehicle, e.g. A6.                                               |
+  | 4        | CarColour      | String | [A-Z0-9] 25 chars      | Colour of vehicle, e.g. White.                                           |


### PR DESCRIPTION
Updating the max length for the car make, model and colour fields to reflect the current limit of 25 characters (rather than 20).