### PR TITLE
Make path examples clear that their product codes

### DIFF
--- a/site/hxapi/hotel/index.md
+++ b/site/hxapi/hotel/index.md
@@ -14,7 +14,7 @@ Here are the hotel specific endpoints:
  | ------                                     | --------                                                                         | ------ |
  | Availability at hotel      | [https://api.holidayextras.co.uk/v1/hotel/LocationCode](av)            | GET    |
  | Make booking at hotel      | [https://api.holidayextras.co.uk/v1/hotel/LocationCode](bkg)           | POST   |
- | Pre-booking price check  | [https://api.holidayextras.co.uk/v1/hotel/LocationCode/priceCheck](priceCheck) | GET    |
+ | Pre-booking price check  | [https://api.holidayextras.co.uk/v1/hotel/HotelProductCode/priceCheck](priceCheck) | GET    |
 
 Please note: All hotel requests include parking options of zero, 8 and 15 days parking. To make a request for a hotel only product, please select zero days parking.
 

--- a/site/hxapi/hotel/priceCheck.md
+++ b/site/hxapi/hotel/priceCheck.md
@@ -17,7 +17,7 @@ GET
 The endpoint to use is:
 
 ```
-https://api.holidayextras.co.uk/v1/hotel/LocationCode/priceCheck
+https://api.holidayextras.co.uk/v1/hotel/HotelProductCode/priceCheck
 ```
 
 For example, for _Mercure at London Heathrow_ the endpoint is:

--- a/site/hxapi/parking/index.md
+++ b/site/hxapi/parking/index.md
@@ -15,7 +15,7 @@ Here are the car parking specific endpoints:
  | Availability at airport  | [https://api.holidayextras.co.uk/v1/carpark/AirportCode](av/airport)            | GET    |
  | Availability at car park | [https://api.holidayextras.co.uk/v1/carpark/CarParkCode](av/carpark)            | GET    |
  | Make booking at car park | [https://api.holidayextras.co.uk/v1/carpark/CarParkCode](bkg)                   | POST   |
- | Pre-booking price check  | [https://api.holidayextras.co.uk/v1/carpark/CarParkCode/priceCheck](priceCheck) | GET    |
+ | Pre-booking price check  | [https://api.holidayextras.co.uk/v1/carpark/CarParkProductCode/priceCheck](priceCheck) | GET    |
 
 ## Parking User Journey
 

--- a/site/hxapi/parking/priceCheck.md
+++ b/site/hxapi/parking/priceCheck.md
@@ -22,7 +22,7 @@ GET
 The endpoint to use is:
 
 ```
-https://api.holidayextras.co.uk/v1/carpark/CarParkCode/priceCheck
+https://api.holidayextras.co.uk/v1/carpark/CarParkProductCode/priceCheck
 ```
 
 For example, for _Maple Manor Meet and Greet at London Gatwick North terminal_ the endpoint is:


### PR DESCRIPTION
Updates the price check docs so that it's clear that the routes expect product codes