### PR TITLE
Update documentation for fast track availability request

### DIFF
--- a/site/_changelog.md
+++ b/site/_changelog.md
@@ -1,5 +1,6 @@
 | Version Number | Date                | Details                                                                                                                        |
 |----------------|---------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| 1.27.0         | 21st May 2025       | Adding list of available locations for FastTrack.                                                                              |
 | 1.26.0         | 25th April 2025     | Added duplicate booking error.                                                                                                 |
 | 1.25.0         | 17th March 2025     | Restore .co.uk dns and sandbox paths                                                                                           |
 | 1.24.0         | 3rd February 2025   | Mark PDF references as deprecated and remove theatrebreak shows link                                                           |

--- a/site/hxapi/fasttrack/av/index.md
+++ b/site/hxapi/fasttrack/av/index.md
@@ -24,7 +24,18 @@ For example, for fasttrack availability at Manchester the endpoint is:
 https://api.holidayextras.co.uk/v1/fasttrack/MAN
 ```
 
-To find the airport locations available for fasttrack, please refer to the [locations endpoint.](/hxapi/locations)
+Available locations for the FastTrack product are
+| IATA | Location Name   |
+|------|-----------------|
+| BOH  | Bournemouth     |
+| BRS  | Bristol         |
+| EDI  | Edinburgh       |
+| EMA  | East Midlands   |
+| LPL  | Liverpool       |
+| LBA  | Leeds Bradford  |
+| MAN  | Manchester      |
+| NCL  | Newcastle       |
+| STN  | Stansted        |
 
 ### Request Parameters
 

--- a/site/hxapi/locations.md
+++ b/site/hxapi/locations.md
@@ -39,7 +39,7 @@ NB: All parameter names are case sensitive.
  | EU     | Lounges | type=lounge&system=de  |
  
  
-## Hotel Availability Response
+## Locations Response
 
 For a detailed explanation of the fields returned, please see below:
 


### PR DESCRIPTION
#### What does this PR do? (please provide any background)
Updates the documentation for the fast track availability request to include a hard coded list of locations for this product.
This is causing some confusion for our partners as the documentation tells partners to call the location endpoint which does not support requests for a fast track product.
Fast track product are not loaded as a fast track product type, they're loaded as upgrades. This means we don't have a way to identify which locations a partner should search for.
The list of fast track locations is fairly static, so hard coding this for now looks like a sensible suggestion for the time being

#### Any tech debt?
Hard coded lists of locations isn't ideal, we should revisit this.

#### Screenshots / Screencast


- I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

By approving a review you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

---
