### PR TITLE
Update terminal and location documentation for fast track product availability

### DIFF
--- a/site/_changelog.md
+++ b/site/_changelog.md
@@ -1,5 +1,6 @@
 | Version Number | Date                | Details                                                                                                                        |
 |----------------|---------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| 1.30.0         | 3rd July 2025       | Update FastTrack availability documentation.                                                                                   |
 | 1.29.0         | 25th June 2025      | Added new error codes.                                                                                                         |
 | 1.28.0         | 5th June 2025       | Added bookingStatus and suggestedPollingInterval to the responses.                                                             |
 | 1.27.1         | 5th June 2025       | Added `GIATA` location type to transfers availability docs                                                                     |

--- a/site/hxapi/fasttrack/av/index.md
+++ b/site/hxapi/fasttrack/av/index.md
@@ -42,7 +42,7 @@ NB: All parameter names are case sensitive.
 | Adults      | Integer   | [0-4] 1 char     | Y          | Number of adults requiring entry to the fasttrack.                                                                                                                                                                                                                                                                                            |
 | Children    | Integer   | [0-3] 1 char     | N          | Number of children requiring entry to the fasttrack.                                                                                                                                                                                                                                                                                          |
 | OutFlight   | String    | [A-Z0-9] 9 chars | N          | This is also known as an 'flight number'. <br>Used to establish which terminal the customer is flying from using our look up tool and return products specific to that terminal.                                                                                                                                                              |
-| Terminal    | String    | [A-Z1-9] 1 char  | N          | An optional field when requesting hotel and parking that will filter the availble results to those that serve the given terminal. Terminal options can be found using the [Terminal](/hxapi/terminal) request, where the name of the terminal is a word only the first character is needed for this request ( eg. N for the North terminal ). |
+
 
 ## FastTrack Availability Response
 
@@ -66,7 +66,8 @@ For a detailed explanation of the fields returned, please see below:
 | FastTrack/Logo             | Link to a logo for the product. Prepend with `https:`                                                       |
 | FastTrack/ExtraInformation | Extended description of the product                                                                         |
 | IsRefundable               | Whether the product can be refunded                                                                         |
-| AirportLocation            | The location code for the product airport                                                                   |
+| AirportLocation            | The location name for the product airport                                                                   |
+| Location                   | The airport location the product is located at and its terminals                                            |
 | Terminal                   | The airport terminal of the product                                                                         |
 
 


### PR DESCRIPTION
#### What does this PR do? (please provide any background)
Updates the documentation for the fast track availability endpoint:
- Removes `Terminal` from the request parameters, this is not supported
- Updates the description for `AirportLocation` in the response
- Adds documentation for `Location` field in the response

#### Any tech debt?
N/A

#### Screenshots / Screencast


- I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

By approving a review you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

---
